### PR TITLE
Filter releases to only include those authored by simonw

### DIFF
--- a/build_readme.py
+++ b/build_readme.py
@@ -50,6 +50,9 @@ query {
             name
             publishedAt
             url
+            author {
+              login
+            }
           }
         }
       }
@@ -79,6 +82,9 @@ query {
             name
             publishedAt
             url
+            author {
+              login
+            }
           }
         }
       }
@@ -121,16 +127,20 @@ def seed_releases_cache(oauth_token):
             if repo["name"] in SKIP_REPOS:
                 continue
             if repo["releases"]["totalCount"]:
+                release_node = repo["releases"]["nodes"][0]
+                release_author = (release_node.get("author") or {}).get("login")
+                if release_author != "simonw":
+                    continue
                 cache[repo["name"]] = {
                     "repo": repo["name"],
                     "repo_url": repo["url"],
                     "description": repo["description"],
-                    "release": repo["releases"]["nodes"][0]["name"]
+                    "release": release_node["name"]
                     .replace(repo["name"], "")
                     .strip(),
-                    "published_at": repo["releases"]["nodes"][0]["publishedAt"],
-                    "published_day": repo["releases"]["nodes"][0]["publishedAt"].split("T")[0],
-                    "url": repo["releases"]["nodes"][0]["url"],
+                    "published_at": release_node["publishedAt"],
+                    "published_day": release_node["publishedAt"].split("T")[0],
+                    "url": release_node["url"],
                     "total_releases": repo["releases"]["totalCount"],
                 }
 
@@ -162,16 +172,20 @@ def fetch_and_update_releases(oauth_token):
         if repo["name"] in SKIP_REPOS:
             continue
         if repo["releases"]["totalCount"]:
+            release_node = repo["releases"]["nodes"][0]
+            release_author = (release_node.get("author") or {}).get("login")
+            if release_author != "simonw":
+                continue
             cache[repo["name"]] = {
                 "repo": repo["name"],
                 "repo_url": repo["url"],
                 "description": repo["description"],
-                "release": repo["releases"]["nodes"][0]["name"]
+                "release": release_node["name"]
                 .replace(repo["name"], "")
                 .strip(),
-                "published_at": repo["releases"]["nodes"][0]["publishedAt"],
-                "published_day": repo["releases"]["nodes"][0]["publishedAt"].split("T")[0],
-                "url": repo["releases"]["nodes"][0]["url"],
+                "published_at": release_node["publishedAt"],
+                "published_day": release_node["publishedAt"].split("T")[0],
+                "url": release_node["url"],
                 "total_releases": repo["releases"]["totalCount"],
             }
 


### PR DESCRIPTION
> Take a look at how this thing gathers release information from GitHub
> 
> How hard would it be to make it so it only includes leases where the most recent commit at that point was authored by simonw - I do not want to include releases that other people shipped

## Summary
Updated the release fetching logic to filter releases based on the author, only including releases published by "simonw".

## Key Changes
- Updated GraphQL queries in both `seed_releases_cache()` and `fetch_and_update_releases()` to request the `author.login` field for each release
- Added filtering logic to skip releases not authored by "simonw" in both functions
- Refactored release node access to use a local variable (`release_node`) for improved code clarity and reduced repetition
- Replaced multiple direct accesses to `repo["releases"]["nodes"][0]` with the `release_node` variable throughout the cache building logic

## Implementation Details
The author filtering is applied after checking that releases exist (`totalCount > 0`) but before adding the repository to the cache. This ensures only releases from the specified author are included in the generated README, while maintaining the existing repository filtering logic.

https://claude.ai/code/session_017axAKT2nwHE6uHjLsZELzq