### PR TITLE
Add GitHub Repo Size checker web tool

### DIFF
--- a/github-repo-size.html
+++ b/github-repo-size.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GitHub Repo Size</title>
+<style>
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+  color: #1f2328;
+}
+h1 { margin-bottom: 1rem; }
+form {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+input {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  font-size: 1rem;
+  border: 1px solid #d1d9e0;
+  border-radius: 6px;
+}
+button {
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  background: #2da44e;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+button:hover { background: #298e46; }
+#result {
+  padding: 1rem;
+  border-radius: 6px;
+  display: none;
+}
+#result.success { display: block; background: #dafbe1; border: 1px solid #82e596; }
+#result.error { display: block; background: #ffebe9; border: 1px solid #ff8182; }
+.size { font-size: 2rem; font-weight: 600; }
+.repo-name { font-weight: 600; }
+.details { margin-top: 0.5rem; color: #656d76; font-size: 0.875rem; }
+</style>
+</head>
+<body>
+<h1>GitHub Repo Size</h1>
+<form id="form">
+  <input id="input" type="text" placeholder="owner/repo or https://github.com/owner/repo" autofocus>
+  <button type="submit">Check</button>
+</form>
+<div id="result"></div>
+<script>
+function parseRepo(input) {
+  input = input.trim().replace(/\/+$/, '');
+  const urlMatch = input.match(/github\.com\/([^/]+)\/([^/]+)/);
+  if (urlMatch) return `${urlMatch[1]}/${urlMatch[2]}`;
+  if (/^[^/\s]+\/[^/\s]+$/.test(input)) return input;
+  return null;
+}
+
+function formatSize(kb) {
+  if (kb < 1024) return { value: kb, unit: 'KB' };
+  const mb = kb / 1024;
+  if (mb < 1024) return { value: mb, unit: 'MB' };
+  const gb = mb / 1024;
+  return { value: gb, unit: 'GB' };
+}
+
+function formatNumber(n) {
+  return n < 10 ? n.toFixed(1) : Math.round(n).toLocaleString();
+}
+
+document.getElementById('form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const result = document.getElementById('result');
+  const repo = parseRepo(document.getElementById('input').value);
+  if (!repo) {
+    result.className = 'error';
+    result.innerHTML = 'Enter a valid repo: <code>owner/repo</code> or a GitHub URL.';
+    return;
+  }
+  result.className = 'success';
+  result.innerHTML = 'Loading&hellip;';
+  try {
+    const res = await fetch(`https://api.github.com/repos/${repo}`);
+    if (!res.ok) throw new Error(res.status === 404 ? 'Repository not found.' : `GitHub API error: ${res.status}`);
+    const data = await res.json();
+    const { value, unit } = formatSize(data.size);
+    result.className = 'success';
+    result.innerHTML = `
+      <div class="repo-name">${data.full_name}</div>
+      <div class="size">${formatNumber(value)} ${unit}</div>
+      <div class="details">${data.size.toLocaleString()} KB (as reported by the GitHub API)</div>
+    `;
+  } catch (err) {
+    result.className = 'error';
+    result.textContent = err.message;
+  }
+});
+</script>
+</body>
+</html>

--- a/github-repo-size.html
+++ b/github-repo-size.html
@@ -76,15 +76,17 @@ function formatNumber(n) {
   return n < 10 ? n.toFixed(1) : Math.round(n).toLocaleString();
 }
 
-document.getElementById('form').addEventListener('submit', async (e) => {
-  e.preventDefault();
+async function checkRepo(repoInput) {
   const result = document.getElementById('result');
-  const repo = parseRepo(document.getElementById('input').value);
+  const repo = parseRepo(repoInput);
   if (!repo) {
     result.className = 'error';
     result.innerHTML = 'Enter a valid repo: <code>owner/repo</code> or a GitHub URL.';
     return;
   }
+  const url = new URL(location.href);
+  url.searchParams.set('repo', repo);
+  history.replaceState(null, '', url);
   result.className = 'success';
   result.innerHTML = 'Loading&hellip;';
   try {
@@ -102,7 +104,18 @@ document.getElementById('form').addEventListener('submit', async (e) => {
     result.className = 'error';
     result.textContent = err.message;
   }
+}
+
+document.getElementById('form').addEventListener('submit', (e) => {
+  e.preventDefault();
+  checkRepo(document.getElementById('input').value);
 });
+
+const initialRepo = new URLSearchParams(location.search).get('repo');
+if (initialRepo) {
+  document.getElementById('input').value = initialRepo;
+  checkRepo(initialRepo);
+}
 </script>
 </body>
 </html>


### PR DESCRIPTION
> Build github-repo-size.html - a tool where you paste in a GitHub repo URL (starting with https://) or just the repo `owner/repo` string and it hits the GitHub API and shows you the size of that repo in an appropriately useful unit. https://api.github.com/repos/jsoma/natural-pdf returns  `"size": 573588` for example

> when a repo is submitted update the page URL to have `?repo=owner/repo` in it, if that is presesnt when the page loads then pre-populate the form and submit it automatically

## Summary
This PR adds a new single-file web application that allows users to quickly check the size of any GitHub repository.

## Key Changes
- Created a new `github-repo-size.html` file with a complete, self-contained web tool
- Implements a clean, GitHub-styled UI with form input for repository lookup
- Supports flexible input formats: `owner/repo` or full GitHub URLs
- Integrates with the GitHub API to fetch repository size information
- Displays repository size in human-readable format (KB, MB, or GB)
- Includes error handling for invalid input and API failures
- Responsive design with proper styling and visual feedback

## Implementation Details
- **Input parsing**: Intelligently handles both shorthand (`owner/repo`) and full GitHub URLs, with URL normalization
- **Size formatting**: Converts API response (in KB) to appropriate units with smart decimal precision
- **API integration**: Uses GitHub's public API endpoint (`/repos/{owner}/{repo}`) with proper error handling for 404s and other HTTP errors
- **UX features**: Loading state, success/error styling, and helpful error messages for user guidance
- **Styling**: GitHub-inspired design using system fonts and GitHub's color palette for consistency

https://claude.ai/code/session_012hmyvXGJX3y14qmp4cAieC