### PR TITLE
Mirror every repo's README.md and releases.json under repos/

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,8 @@ on:
   push:
   workflow_dispatch:
     inputs:
-      seed:
-        description: 'Seed the releases cache with full data (run once)'
+      all:
+        description: 'Run against every repo (full scan, ignores the 3-hour window)'
         required: false
         type: boolean
         default: false
@@ -30,8 +30,8 @@ jobs:
       env:
         SIMONW_TOKEN: ${{ secrets.SIMONW_TOKEN }}
       run: |-
-        if [ "${{ inputs.seed }}" = "true" ]; then
-          python build_readme.py --seed
+        if [ "${{ inputs.all }}" = "true" ]; then
+          python build_readme.py --all
         else
           python build_readme.py
         fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/build_readme.py
+++ b/build_readme.py
@@ -1,4 +1,5 @@
 from python_graphql_client import GraphqlClient
+from datetime import datetime, timedelta, timezone
 import feedparser
 import httpx
 import json
@@ -11,6 +12,12 @@ root = pathlib.Path(__file__).parent.resolve()
 client = GraphqlClient(endpoint="https://api.github.com/graphql")
 
 TOKEN = os.environ.get("SIMONW_TOKEN", "")
+
+OWNERS = "owner:simonw owner:dogsheep owner:datasette"
+
+# How many hours back the scheduled (incremental) run looks at. The workflow
+# runs hourly, so 3 hours gives a comfortable overlap in case a run is skipped.
+INCREMENTAL_HOURS = 3
 
 SKIP_REPOS = {
     "playing-with-actions",
@@ -35,40 +42,12 @@ def replace_chunk(content, marker, chunk, inline=False):
     return r.sub(chunk, content)
 
 
+# Single search query template. QUERY_STRING and AFTER are substituted in. Each
+# repo node carries its README (a few common filename spellings are requested as
+# aliases) so we never need a second fetch to mirror it.
 GRAPHQL_SEARCH_QUERY = """
 query {
-  search(first: 100, type:REPOSITORY, query:"is:public owner:simonw owner:dogsheep owner:datasette sort:updated") {
-    nodes {
-      __typename
-      ... on Repository {
-        name
-        description
-        url
-        owner {
-          login
-        }
-        releases(orderBy: {field: CREATED_AT, direction: DESC}, first: 10) {
-          totalCount
-          nodes {
-            name
-            publishedAt
-            url
-            author {
-              login
-            }
-          }
-        }
-      }
-    }
-  }
-}
-"""
-
-RELEASES_CACHE_PATH = root / "releases_cache.json"
-
-GRAPHQL_SEARCH_QUERY_PAGINATED = """
-query {
-  search(first: 100, type:REPOSITORY, query:"is:public owner:simonw owner:dogsheep owner:datasette sort:updated", after: AFTER) {
+  search(first: 100, type: REPOSITORY, query: "QUERY_STRING", after: AFTER) {
     pageInfo {
       hasNextPage
       endCursor
@@ -82,6 +61,11 @@ query {
         owner {
           login
         }
+        readme_md: object(expression: "HEAD:README.md") { ... on Blob { text } }
+        readme_markdown: object(expression: "HEAD:README.markdown") { ... on Blob { text } }
+        readme_lower: object(expression: "HEAD:readme.md") { ... on Blob { text } }
+        readme_rst: object(expression: "HEAD:README.rst") { ... on Blob { text } }
+        readme_plain: object(expression: "HEAD:README") { ... on Blob { text } }
         releases(orderBy: {field: CREATED_AT, direction: DESC}, first: 100) {
           totalCount
           pageInfo {
@@ -103,6 +87,9 @@ query {
 }
 """
 
+RELEASES_CACHE_PATH = root / "releases_cache.json"
+REPOS_DIR = root / "repos"
+
 GRAPHQL_REPO_RELEASES_QUERY = """
 query {
   repository(owner: "OWNER", name: "NAME") {
@@ -123,6 +110,25 @@ query {
   }
 }
 """
+
+
+def everything_query():
+    """Search query matching every public repo across the owners."""
+    return "is:public {} sort:updated".format(OWNERS)
+
+
+def incremental_query(hours=INCREMENTAL_HOURS):
+    """Search query limited to repos pushed within the last `hours` hours."""
+    since = (datetime.now(timezone.utc) - timedelta(hours=hours)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    return "is:public {} pushed:>{} sort:updated".format(OWNERS, since)
+
+
+def build_search_query(query_string, after_cursor):
+    return GRAPHQL_SEARCH_QUERY.replace("QUERY_STRING", query_string).replace(
+        "AFTER", '"{}"'.format(after_cursor) if after_cursor else "null"
+    )
 
 
 def make_release_entry(repo_name, release_node):
@@ -187,118 +193,114 @@ def save_releases_cache(cache):
     RELEASES_CACHE_PATH.write_text(json.dumps(cache, indent=2, sort_keys=True))
 
 
-def seed_releases_cache(oauth_token):
-    """Fetch ALL releases via pagination to seed the cache. Run once with --seed."""
-    cache = {}
-    has_next_page = True
+def pick_readme(repo):
+    """Return the first available README text from the aliased blob fields."""
+    for key in ("readme_md", "readme_markdown", "readme_lower", "readme_rst", "readme_plain"):
+        obj = repo.get(key)
+        if obj and obj.get("text"):
+            return obj["text"]
+    return None
+
+
+def update_cache_releases(cache, repo, full_release_pagination):
+    """Merge a repo's releases into the cache. Returns nothing; mutates cache."""
+    name = repo["name"]
+    total = repo["releases"]["totalCount"]
+    if not total:
+        return
+
+    new_releases = filter_releases_by_author(name, repo["releases"]["nodes"])
+
+    # Only the seed/full run deep-paginates repos with >100 releases; the
+    # incremental run relies on the cache already holding the older ones.
+    if full_release_pagination and repo["releases"]["pageInfo"]["hasNextPage"]:
+        new_releases.extend(
+            fetch_all_repo_releases(
+                TOKEN,
+                repo["owner"]["login"],
+                name,
+                repo["releases"]["pageInfo"]["endCursor"],
+            )
+        )
+
+    if name in cache:
+        existing_urls = {r["url"] for r in cache[name]["releases"]}
+        for release in new_releases:
+            if release["url"] not in existing_urls:
+                cache[name]["releases"].append(release)
+        cache[name]["releases"].sort(key=lambda r: r["published_at"], reverse=True)
+        cache[name]["description"] = repo["description"]
+        cache[name]["total_releases"] = total
+    elif new_releases:
+        cache[name] = {
+            "repo": name,
+            "repo_url": repo["url"],
+            "description": repo["description"],
+            "total_releases": total,
+            "releases": new_releases,
+        }
+
+
+def write_repo_files(repo, cache):
+    """Write repos/<owner>/<repo>/README.md and releases.json for one repo."""
+    owner = repo["owner"]["login"]
+    name = repo["name"]
+    repo_dir = REPOS_DIR / owner / name
+    repo_dir.mkdir(parents=True, exist_ok=True)
+
+    readme_text = pick_readme(repo)
+    if readme_text is not None:
+        (repo_dir / "README.md").write_text(readme_text)
+
+    cached = cache.get(name)
+    releases_json = {
+        "repo": name,
+        "owner": owner,
+        "url": repo["url"],
+        "description": repo["description"],
+        "total_releases": repo["releases"]["totalCount"],
+        "releases": cached["releases"] if cached else [],
+    }
+    (repo_dir / "releases.json").write_text(
+        json.dumps(releases_json, indent=2, sort_keys=True)
+    )
+
+
+def fetch_repos(query_string):
+    """Paginate the repo search and return every matching repo node."""
+    nodes = []
     after_cursor = None
+    has_next_page = True
 
     while has_next_page:
-        query = GRAPHQL_SEARCH_QUERY_PAGINATED.replace(
-            "AFTER", '"{}"'.format(after_cursor) if after_cursor else "null"
-        )
         data = client.execute(
-            query=query,
-            headers={"Authorization": "Bearer {}".format(oauth_token)},
+            query=build_search_query(query_string, after_cursor),
+            headers={"Authorization": "Bearer {}".format(TOKEN)},
         )
-        print(json.dumps(data, indent=4))
+        search = data["data"]["search"]
+        nodes.extend(search["nodes"])
+        page_info = search["pageInfo"]
+        has_next_page = page_info["hasNextPage"]
+        after_cursor = page_info["endCursor"]
 
-        repo_nodes = data["data"]["search"]["nodes"]
-        for repo in repo_nodes:
-            if repo["name"] in SKIP_REPOS:
-                continue
-            if not repo["releases"]["totalCount"]:
-                continue
-
-            releases = filter_releases_by_author(
-                repo["name"], repo["releases"]["nodes"]
-            )
-
-            # Paginate if this repo has more releases
-            release_page_info = repo["releases"]["pageInfo"]
-            if release_page_info["hasNextPage"]:
-                owner = repo["owner"]["login"]
-                print(
-                    f"  Paginating releases for {owner}/{repo['name']}..."
-                )
-                releases.extend(
-                    fetch_all_repo_releases(
-                        oauth_token,
-                        owner,
-                        repo["name"],
-                        release_page_info["endCursor"],
-                    )
-                )
-
-            if releases:
-                cache[repo["name"]] = {
-                    "repo": repo["name"],
-                    "repo_url": repo["url"],
-                    "description": repo["description"],
-                    "total_releases": repo["releases"]["totalCount"],
-                    "releases": releases,
-                }
-
-        after_cursor = data["data"]["search"]["pageInfo"]["endCursor"]
-        has_next_page = after_cursor
-
-    save_releases_cache(cache)
-    total_releases = sum(len(r["releases"]) for r in cache.values())
-    print(f"Seeded cache with {len(cache)} repos, {total_releases} releases")
-    return cache
+    return nodes
 
 
-def fetch_and_update_releases(oauth_token):
-    """Fetch recent releases and merge into cache. Returns cache dict."""
-    # Load existing cache
+def build(query_string, full_release_pagination):
+    """Scan repos matching query_string, mirror their files, update the cache."""
     cache = load_releases_cache()
+    repo_nodes = fetch_repos(query_string)
 
-    # Fetch the 100 most recently updated repos (single API call)
-    data = client.execute(
-        query=GRAPHQL_SEARCH_QUERY,
-        headers={"Authorization": "Bearer {}".format(oauth_token)},
-    )
-    print()
-    print(json.dumps(data, indent=4))
-    print()
-
-    # Update cache with fresh data
-    repo_nodes = data["data"]["search"]["nodes"]
+    written = 0
     for repo in repo_nodes:
         if repo["name"] in SKIP_REPOS:
             continue
-        if not repo["releases"]["totalCount"]:
-            continue
+        update_cache_releases(cache, repo, full_release_pagination)
+        write_repo_files(repo, cache)
+        written += 1
 
-        new_releases = filter_releases_by_author(
-            repo["name"], repo["releases"]["nodes"]
-        )
-
-        if repo["name"] in cache:
-            # Merge: add any new releases not already in cache
-            existing_urls = {r["url"] for r in cache[repo["name"]]["releases"]}
-            for release in new_releases:
-                if release["url"] not in existing_urls:
-                    cache[repo["name"]]["releases"].append(release)
-            # Re-sort by published_at descending
-            cache[repo["name"]]["releases"].sort(
-                key=lambda r: r["published_at"], reverse=True
-            )
-            # Update repo metadata
-            cache[repo["name"]]["description"] = repo["description"]
-            cache[repo["name"]]["total_releases"] = repo["releases"]["totalCount"]
-        elif new_releases:
-            cache[repo["name"]] = {
-                "repo": repo["name"],
-                "repo_url": repo["url"],
-                "description": repo["description"],
-                "total_releases": repo["releases"]["totalCount"],
-                "releases": new_releases,
-            }
-
-    # Save updated cache
     save_releases_cache(cache)
-
+    print("Scanned {} repos, wrote files for {}".format(len(repo_nodes), written))
     return cache
 
 
@@ -351,11 +353,22 @@ if __name__ == "__main__":
     readme = root / "README.md"
     project_releases = root / "releases.md"
 
-    if "--seed" in sys.argv or not RELEASES_CACHE_PATH.exists():
-        print("Seeding releases cache with full pagination...")
-        cache = seed_releases_cache(TOKEN)
+    # --all (or --seed) scans every repo; an empty cache forces a full scan too.
+    # Otherwise the scheduled run only looks at repos pushed in the last few hours.
+    if (
+        "--all" in sys.argv
+        or "--seed" in sys.argv
+        or not RELEASES_CACHE_PATH.exists()
+    ):
+        print("Running full scan against every repo...")
+        cache = build(everything_query(), full_release_pagination=True)
     else:
-        cache = fetch_and_update_releases(TOKEN)
+        print(
+            "Running incremental scan (repos pushed in the last {} hours)...".format(
+                INCREMENTAL_HOURS
+            )
+        )
+        cache = build(incremental_query(), full_release_pagination=False)
 
     releases = most_recent_releases(cache)
     releases.sort(key=lambda r: r["published_at"], reverse=True)

--- a/build_readme.py
+++ b/build_readme.py
@@ -141,6 +141,13 @@ def make_release_entry(repo_name, release_node):
     }
 
 
+def make_release_entry_with_author(repo_name, release_node):
+    """Release dict including the author login, for the per-repo releases.json."""
+    entry = make_release_entry(repo_name, release_node)
+    entry["author"] = (release_node.get("author") or {}).get("login")
+    return entry
+
+
 def filter_releases_by_author(repo_name, release_nodes):
     """Return release entries for releases authored by simonw."""
     releases = []
@@ -152,9 +159,9 @@ def filter_releases_by_author(repo_name, release_nodes):
     return releases
 
 
-def fetch_all_repo_releases(oauth_token, owner, name, after_cursor):
-    """Paginate through remaining releases for a single repo."""
-    releases = []
+def paginate_repo_releases(oauth_token, owner, name, after_cursor):
+    """Return all remaining raw release nodes for a single repo."""
+    nodes = []
     has_next_page = True
 
     while has_next_page:
@@ -168,17 +175,38 @@ def fetch_all_repo_releases(oauth_token, owner, name, after_cursor):
             headers={"Authorization": "Bearer {}".format(oauth_token)},
         )
         releases_data = data["data"]["repository"]["releases"]
-        for node in releases_data["nodes"]:
-            author = (node.get("author") or {}).get("login")
-            if author != "simonw":
-                continue
-            releases.append(make_release_entry(name, node))
+        nodes.extend(releases_data["nodes"])
 
         page_info = releases_data["pageInfo"]
         has_next_page = page_info["hasNextPage"]
         after_cursor = page_info["endCursor"]
 
-    return releases
+    return nodes
+
+
+def fetch_all_repo_releases(oauth_token, owner, name, after_cursor):
+    """Paginate remaining releases for a repo, keeping only simonw-authored ones."""
+    nodes = paginate_repo_releases(oauth_token, owner, name, after_cursor)
+    return [
+        make_release_entry(name, node)
+        for node in nodes
+        if (node.get("author") or {}).get("login") == "simonw"
+    ]
+
+
+def collect_all_releases(repo):
+    """All releases (every author) for a repo, fully paginated, for releases.json."""
+    rel = repo["releases"]
+    if not rel["totalCount"]:
+        return []
+    nodes = list(rel["nodes"])
+    if rel["pageInfo"]["hasNextPage"]:
+        nodes.extend(
+            paginate_repo_releases(
+                TOKEN, repo["owner"]["login"], repo["name"], rel["pageInfo"]["endCursor"]
+            )
+        )
+    return [make_release_entry_with_author(repo["name"], node) for node in nodes]
 
 
 def load_releases_cache():
@@ -241,7 +269,7 @@ def update_cache_releases(cache, repo, full_release_pagination):
         }
 
 
-def write_repo_files(repo, cache):
+def write_repo_files(repo, all_releases):
     """Write repos/<owner>/<repo>/README.md and releases.json for one repo."""
     owner = repo["owner"]["login"]
     name = repo["name"]
@@ -252,14 +280,13 @@ def write_repo_files(repo, cache):
     if readme_text is not None:
         (repo_dir / "README.md").write_text(readme_text)
 
-    cached = cache.get(name)
     releases_json = {
         "repo": name,
         "owner": owner,
         "url": repo["url"],
         "description": repo["description"],
         "total_releases": repo["releases"]["totalCount"],
-        "releases": cached["releases"] if cached else [],
+        "releases": all_releases,
     }
     (repo_dir / "releases.json").write_text(
         json.dumps(releases_json, indent=2, sort_keys=True)
@@ -296,7 +323,7 @@ def build(query_string, full_release_pagination):
         if repo["name"] in SKIP_REPOS:
             continue
         update_cache_releases(cache, repo, full_release_pagination)
-        write_repo_files(repo, cache)
+        write_repo_files(repo, collect_all_releases(repo))
         written += 1
 
     save_releases_cache(cache)

--- a/repos/simonw/datasette/README.md
+++ b/repos/simonw/datasette/README.md
@@ -1,0 +1,91 @@
+<img src="https://datasette.io/static/datasette-logo.svg" alt="Datasette">
+
+[![PyPI](https://img.shields.io/pypi/v/datasette.svg)](https://pypi.org/project/datasette/)
+[![Changelog](https://img.shields.io/github/v/release/simonw/datasette?label=changelog)](https://docs.datasette.io/en/latest/changelog.html)
+[![Python 3.x](https://img.shields.io/pypi/pyversions/datasette.svg?logo=python&logoColor=white)](https://pypi.org/project/datasette/)
+[![Tests](https://github.com/simonw/datasette/workflows/Test/badge.svg)](https://github.com/simonw/datasette/actions?query=workflow%3ATest)
+[![Documentation Status](https://readthedocs.org/projects/datasette/badge/?version=latest)](https://docs.datasette.io/en/latest/?badge=latest)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/simonw/datasette/blob/main/LICENSE)
+[![docker: datasette](https://img.shields.io/badge/docker-datasette-blue)](https://hub.docker.com/r/datasetteproject/datasette)
+[![discord](https://img.shields.io/discord/823971286308356157?label=discord)](https://datasette.io/discord)
+
+*An open source multi-tool for exploring and publishing data*
+
+Datasette is a tool for exploring and publishing data. It helps people take data of any shape or size and publish that as an interactive, explorable website and accompanying API.
+
+Datasette is aimed at data journalists, museum curators, archivists, local governments, scientists, researchers and anyone else who has data that they wish to share with the world.
+
+[Explore a demo](https://datasette.io/global-power-plants/global-power-plants), watch [a video about the project](https://simonwillison.net/2021/Feb/7/video/) or try it out [on GitHub Codespaces](https://github.com/datasette/datasette-studio).
+
+* [datasette.io](https://datasette.io/) is the official project website
+* Latest [Datasette News](https://datasette.io/news)
+* Comprehensive documentation: https://docs.datasette.io/
+* Examples: https://datasette.io/examples
+* Live demo of current `main` branch: https://latest.datasette.io/
+* Questions, feedback or want to talk about the project? Join our [Discord](https://datasette.io/discord)
+
+Want to stay up-to-date with the project? Subscribe to the [Datasette newsletter](https://datasette.substack.com/) for tips, tricks and news on what's new in the Datasette ecosystem.
+
+## Installation
+
+If you are on a Mac, [Homebrew](https://brew.sh/) is the easiest way to install Datasette:
+
+    brew install datasette
+
+You can also install it using `pip` or `pipx`:
+
+    pip install datasette
+
+Datasette requires Python 3.8 or higher. We also have [detailed installation instructions](https://docs.datasette.io/en/stable/installation.html) covering other options such as Docker.
+
+## Basic usage
+
+    datasette serve path/to/database.db
+
+This will start a web server on port 8001 - visit http://localhost:8001/ to access the web interface.
+
+`serve` is the default subcommand, you can omit it if you like.
+
+Use Chrome on OS X? You can run datasette against your browser history like so:
+
+     datasette ~/Library/Application\ Support/Google/Chrome/Default/History --nolock
+
+Now visiting http://localhost:8001/History/downloads will show you a web interface to browse your downloads data:
+
+![Downloads table rendered by datasette](https://static.simonwillison.net/static/2017/datasette-downloads.png)
+
+## metadata.json
+
+If you want to include licensing and source information in the generated datasette website you can do so using a JSON file that looks something like this:
+
+    {
+        "title": "Five Thirty Eight",
+        "license": "CC Attribution 4.0 License",
+        "license_url": "http://creativecommons.org/licenses/by/4.0/",
+        "source": "fivethirtyeight/data on GitHub",
+        "source_url": "https://github.com/fivethirtyeight/data"
+    }
+
+Save this in `metadata.json` and run Datasette like so:
+
+    datasette serve fivethirtyeight.db -m metadata.json
+
+The license and source information will be displayed on the index page and in the footer. They will also be included in the JSON produced by the API.
+
+## datasette publish
+
+If you have [Heroku](https://heroku.com/) or [Google Cloud Run](https://cloud.google.com/run/) configured, Datasette can deploy one or more SQLite databases to the internet with a single command:
+
+    datasette publish heroku database.db
+
+Or:
+
+    datasette publish cloudrun database.db
+
+This will create a docker image containing both the datasette application and the specified SQLite database files. It will then deploy that image to Heroku or Cloud Run and give you a URL to access the resulting website and API.
+
+See [Publishing data](https://docs.datasette.io/en/stable/publish.html) in the documentation for more details.
+
+## Datasette Lite
+
+[Datasette Lite](https://lite.datasette.io/) is Datasette packaged using WebAssembly so that it runs entirely in your browser, no Python web application server required. Read more about that in the [Datasette Lite documentation](https://github.com/simonw/datasette-lite/blob/main/README.md).

--- a/repos/simonw/datasette/releases.json
+++ b/repos/simonw/datasette/releases.json
@@ -1,0 +1,1005 @@
+{
+  "description": "An open source multi-tool for exploring and publishing data",
+  "owner": "simonw",
+  "releases": [
+    {
+      "published_at": "2026-06-16T21:31:24Z",
+      "published_day": "2026-06-16",
+      "release": "1.0a34",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a34"
+    },
+    {
+      "published_at": "2026-06-11T15:26:49Z",
+      "published_day": "2026-06-11",
+      "release": "1.0a33",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a33"
+    },
+    {
+      "published_at": "2026-05-31T23:23:38Z",
+      "published_day": "2026-05-31",
+      "release": "1.0a32",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a32"
+    },
+    {
+      "published_at": "2026-05-29T03:32:02Z",
+      "published_day": "2026-05-29",
+      "release": "1.0a31",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a31"
+    },
+    {
+      "published_at": "2026-05-24T21:20:14Z",
+      "published_day": "2026-05-24",
+      "release": "1.0a30",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a30"
+    },
+    {
+      "published_at": "2026-05-12T23:41:06Z",
+      "published_day": "2026-05-12",
+      "release": "1.0a29",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a29"
+    },
+    {
+      "published_at": "2026-04-17T04:01:56Z",
+      "published_day": "2026-04-17",
+      "release": "1.0a28",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a28"
+    },
+    {
+      "published_at": "2026-04-15T23:16:34Z",
+      "published_day": "2026-04-15",
+      "release": "1.0a27",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a27"
+    },
+    {
+      "published_at": "2026-03-18T22:16:19Z",
+      "published_day": "2026-03-18",
+      "release": "1.0a26",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a26"
+    },
+    {
+      "published_at": "2026-02-26T00:50:43Z",
+      "published_day": "2026-02-26",
+      "release": "1.0a25",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a25"
+    },
+    {
+      "published_at": "2026-01-29T17:04:33Z",
+      "published_day": "2026-01-29",
+      "release": "1.0a24",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a24"
+    },
+    {
+      "published_at": "2025-12-03T03:21:50Z",
+      "published_day": "2025-12-03",
+      "release": "1.0a23",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a23"
+    },
+    {
+      "published_at": "2025-11-13T18:42:02Z",
+      "published_day": "2025-11-13",
+      "release": "1.0a22",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a22"
+    },
+    {
+      "published_at": "2025-11-05T21:55:15Z",
+      "published_day": "2025-11-05",
+      "release": "1.0a21",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a21"
+    },
+    {
+      "published_at": "2025-11-05T18:20:30Z",
+      "published_day": "2025-11-05",
+      "release": "0.65.2",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.65.2"
+    },
+    {
+      "published_at": "2025-11-03T22:50:28Z",
+      "published_day": "2025-11-03",
+      "release": "1.0a20",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a20"
+    },
+    {
+      "published_at": "2025-04-22T05:39:37Z",
+      "published_day": "2025-04-22",
+      "release": "1.0a19",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a19"
+    },
+    {
+      "published_at": "2025-04-17T05:18:09Z",
+      "published_day": "2025-04-17",
+      "release": "1.0a18",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a18"
+    },
+    {
+      "published_at": "2025-02-06T19:14:10Z",
+      "published_day": "2025-02-06",
+      "release": "1.0a17",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a17"
+    },
+    {
+      "published_at": "2024-11-29T01:13:13Z",
+      "published_day": "2024-11-29",
+      "release": "0.65.1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.65.1"
+    },
+    {
+      "published_at": "2024-10-07T17:38:03Z",
+      "published_day": "2024-10-07",
+      "release": "0.65",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.65"
+    },
+    {
+      "published_at": "2024-09-06T03:58:44Z",
+      "published_day": "2024-09-06",
+      "release": "1.0a16",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a16"
+    },
+    {
+      "published_at": "2024-08-16T05:05:47Z",
+      "published_day": "2024-08-16",
+      "release": "1.0a15",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a15"
+    },
+    {
+      "published_at": "2024-08-05T21:31:43Z",
+      "published_day": "2024-08-05",
+      "release": "1.0a14",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a14"
+    },
+    {
+      "published_at": "2024-06-21T23:42:18Z",
+      "published_day": "2024-06-21",
+      "release": "0.64.8",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.64.8"
+    },
+    {
+      "published_at": "2024-06-12T23:09:31Z",
+      "published_day": "2024-06-12",
+      "release": "0.64.7",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.64.7"
+    },
+    {
+      "published_at": "2024-03-13T02:14:36Z",
+      "published_day": "2024-03-13",
+      "release": "1.0a13",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a13"
+    },
+    {
+      "published_at": "2024-02-29T22:36:42Z",
+      "published_day": "2024-02-29",
+      "release": "1.0a12",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a12"
+    },
+    {
+      "published_at": "2024-02-19T22:52:29Z",
+      "published_day": "2024-02-19",
+      "release": "1.0a11",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a11"
+    },
+    {
+      "published_at": "2024-02-18T05:04:08Z",
+      "published_day": "2024-02-18",
+      "release": "1.0a10",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a10"
+    },
+    {
+      "published_at": "2024-02-16T22:39:38Z",
+      "published_day": "2024-02-16",
+      "release": "1.0a9",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a9"
+    },
+    {
+      "published_at": "2024-02-07T16:37:33Z",
+      "published_day": "2024-02-07",
+      "release": "1.0a8",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a8"
+    },
+    {
+      "published_at": "2023-12-22T23:19:30Z",
+      "published_day": "2023-12-22",
+      "release": "0.64.6",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.64.6"
+    },
+    {
+      "published_at": "2023-10-08T16:05:20Z",
+      "published_day": "2023-10-08",
+      "release": "0.64.5",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.64.5"
+    },
+    {
+      "published_at": "2023-09-21T22:13:27Z",
+      "published_day": "2023-09-21",
+      "release": "1.0a7",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a7"
+    },
+    {
+      "published_at": "2023-09-21T19:43:54Z",
+      "published_day": "2023-09-21",
+      "release": "0.64.4",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.64.4"
+    },
+    {
+      "published_at": "2023-09-08T04:45:12Z",
+      "published_day": "2023-09-08",
+      "release": "1.0a6",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a6"
+    },
+    {
+      "published_at": "2023-08-29T17:19:35Z",
+      "published_day": "2023-08-29",
+      "release": "1.0a5",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a5"
+    },
+    {
+      "published_at": "2023-08-22T17:13:26Z",
+      "published_day": "2023-08-22",
+      "release": "1.0a4",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a4"
+    },
+    {
+      "published_at": "2023-08-09T19:17:26Z",
+      "published_day": "2023-08-09",
+      "release": "1.0a3",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a3"
+    },
+    {
+      "published_at": "2023-04-27T15:00:27Z",
+      "published_day": "2023-04-27",
+      "release": "0.64.3",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.64.3"
+    },
+    {
+      "published_at": "2023-03-08T20:46:27Z",
+      "published_day": "2023-03-08",
+      "release": "0.64.2",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.64.2"
+    },
+    {
+      "published_at": "2023-01-11T18:27:56Z",
+      "published_day": "2023-01-11",
+      "release": "0.64.1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.64.1"
+    },
+    {
+      "published_at": "2023-01-09T16:49:04Z",
+      "published_day": "2023-01-09",
+      "release": "0.64",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.64"
+    },
+    {
+      "published_at": "2022-12-18T03:10:52Z",
+      "published_day": "2022-12-18",
+      "release": "0.63.3",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.63.3"
+    },
+    {
+      "published_at": "2022-12-15T02:03:59Z",
+      "published_day": "2022-12-15",
+      "release": "1.0a2",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a2"
+    },
+    {
+      "published_at": "2022-12-01T21:42:45Z",
+      "published_day": "2022-12-01",
+      "release": "1.0a1",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a1"
+    },
+    {
+      "published_at": "2022-11-29T19:58:55Z",
+      "published_day": "2022-11-29",
+      "release": "1.0a0",
+      "url": "https://github.com/simonw/datasette/releases/tag/1.0a0"
+    },
+    {
+      "published_at": "2022-11-19T00:58:27Z",
+      "published_day": "2022-11-19",
+      "release": "0.63.2",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.63.2"
+    },
+    {
+      "published_at": "2022-11-11T07:02:36Z",
+      "published_day": "2022-11-11",
+      "release": "0.63.1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.63.1"
+    },
+    {
+      "published_at": "2022-10-27T22:13:32Z",
+      "published_day": "2022-10-27",
+      "release": "0.63",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.63"
+    },
+    {
+      "published_at": "2022-10-24T03:11:47Z",
+      "published_day": "2022-10-24",
+      "release": "0.63a1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.63a1"
+    },
+    {
+      "published_at": "2022-09-26T21:56:30Z",
+      "published_day": "2022-09-26",
+      "release": "0.63a0",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.63a0"
+    },
+    {
+      "published_at": "2022-08-14T17:43:05Z",
+      "published_day": "2022-08-14",
+      "release": "0.62",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.62"
+    },
+    {
+      "published_at": "2022-07-18T01:09:05Z",
+      "published_day": "2022-07-18",
+      "release": "0.62a1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.62a1"
+    },
+    {
+      "published_at": "2022-05-02T21:39:52Z",
+      "published_day": "2022-05-02",
+      "release": "0.62a0",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.62a0"
+    },
+    {
+      "published_at": "2022-03-23T20:31:09Z",
+      "published_day": "2022-03-23",
+      "release": "0.61.1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.61.1"
+    },
+    {
+      "published_at": "2022-03-23T18:14:36Z",
+      "published_day": "2022-03-23",
+      "release": "0.61",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.61"
+    },
+    {
+      "published_at": "2022-03-20T01:16:41Z",
+      "published_day": "2022-03-20",
+      "release": "0.61a0",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.61a0"
+    },
+    {
+      "published_at": "2022-02-07T23:49:38Z",
+      "published_day": "2022-02-07",
+      "release": "0.60.2",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.60.2"
+    },
+    {
+      "published_at": "2022-01-21T02:12:54Z",
+      "published_day": "2022-01-21",
+      "release": "0.60.1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.60.1"
+    },
+    {
+      "published_at": "2022-01-14T01:41:28Z",
+      "published_day": "2022-01-14",
+      "release": "0.60",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.60"
+    },
+    {
+      "published_at": "2021-12-19T22:11:16Z",
+      "published_day": "2021-12-19",
+      "release": "0.60a1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.60a1"
+    },
+    {
+      "published_at": "2021-12-17T19:15:38Z",
+      "published_day": "2021-12-17",
+      "release": "0.60a0",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.60a0"
+    },
+    {
+      "published_at": "2021-11-30T06:50:48Z",
+      "published_day": "2021-11-30",
+      "release": "0.59.4",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.59.4"
+    },
+    {
+      "published_at": "2021-11-20T23:41:33Z",
+      "published_day": "2021-11-20",
+      "release": "0.59.3",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.59.3"
+    },
+    {
+      "published_at": "2021-11-14T05:43:09Z",
+      "published_day": "2021-11-14",
+      "release": "0.59.2",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.59.2"
+    },
+    {
+      "published_at": "2021-10-24T22:32:25Z",
+      "published_day": "2021-10-24",
+      "release": "0.59.1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.59.1"
+    },
+    {
+      "published_at": "2021-10-14T19:31:56Z",
+      "published_day": "2021-10-14",
+      "release": "0.59",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.59"
+    },
+    {
+      "published_at": "2021-08-28T01:57:38Z",
+      "published_day": "2021-08-28",
+      "release": "0.59a2",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.59a2"
+    },
+    {
+      "published_at": "2021-08-09T01:14:06Z",
+      "published_day": "2021-08-09",
+      "release": "0.59a1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.59a1"
+    },
+    {
+      "published_at": "2021-08-07T05:42:25Z",
+      "published_day": "2021-08-07",
+      "release": "0.59a0",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.59a0"
+    },
+    {
+      "published_at": "2021-07-16T19:51:15Z",
+      "published_day": "2021-07-16",
+      "release": "0.58.1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.58.1"
+    },
+    {
+      "published_at": "2021-07-15T00:37:57Z",
+      "published_day": "2021-07-15",
+      "release": "0.58",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.58"
+    },
+    {
+      "published_at": "2021-06-24T16:29:09Z",
+      "published_day": "2021-06-24",
+      "release": "0.58a1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.58a1"
+    },
+    {
+      "published_at": "2021-06-10T04:52:45Z",
+      "published_day": "2021-06-10",
+      "release": "0.58a0",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.58a0"
+    },
+    {
+      "published_at": "2021-06-08T16:28:31Z",
+      "published_day": "2021-06-08",
+      "release": "0.57.1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.57.1"
+    },
+    {
+      "published_at": "2021-06-05T22:11:18Z",
+      "published_day": "2021-06-05",
+      "release": "0.57",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.57"
+    },
+    {
+      "published_at": "2021-06-05T22:00:01Z",
+      "published_day": "2021-06-05",
+      "release": "0.56.1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.56.1"
+    },
+    {
+      "published_at": "2021-05-27T16:58:41Z",
+      "published_day": "2021-05-27",
+      "release": "0.57a1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.57a1"
+    },
+    {
+      "published_at": "2021-05-23T00:46:44Z",
+      "published_day": "2021-05-23",
+      "release": "0.57a0",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.57a0"
+    },
+    {
+      "published_at": "2021-03-29T00:43:36Z",
+      "published_day": "2021-03-29",
+      "release": "0.56",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.56"
+    },
+    {
+      "published_at": "2021-02-19T02:02:29Z",
+      "published_day": "2021-02-19",
+      "release": "0.55",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.55"
+    },
+    {
+      "published_at": "2021-02-02T21:30:12Z",
+      "published_day": "2021-02-02",
+      "release": "0.54.1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.54.1"
+    },
+    {
+      "published_at": "2021-01-25T17:36:30Z",
+      "published_day": "2021-01-25",
+      "release": "0.54",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.54"
+    },
+    {
+      "published_at": "2021-01-19T20:51:13Z",
+      "published_day": "2021-01-19",
+      "release": "0.54a0",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.54a0"
+    },
+    {
+      "published_at": "2020-12-11T01:46:44Z",
+      "published_day": "2020-12-11",
+      "release": "0.53",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.53"
+    },
+    {
+      "published_at": "2020-12-09T20:10:23Z",
+      "published_day": "2020-12-09",
+      "release": "0.52.5",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.52.5"
+    },
+    {
+      "published_at": "2020-12-05T19:42:57Z",
+      "published_day": "2020-12-05",
+      "release": "0.52.4",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.52.4"
+    },
+    {
+      "published_at": "2020-12-03T19:08:29Z",
+      "published_day": "2020-12-03",
+      "release": "0.52.3",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.52.3"
+    },
+    {
+      "published_at": "2020-12-03T00:58:43Z",
+      "published_day": "2020-12-03",
+      "release": "0.52.2",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.52.2"
+    },
+    {
+      "published_at": "2020-11-29T19:39:52Z",
+      "published_day": "2020-11-29",
+      "release": "0.52.1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.52.1"
+    },
+    {
+      "published_at": "2020-11-28T23:57:12Z",
+      "published_day": "2020-11-28",
+      "release": "0.52",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.52"
+    },
+    {
+      "published_at": "2020-11-01T03:34:36Z",
+      "published_day": "2020-11-01",
+      "release": "0.51.1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.51.1"
+    },
+    {
+      "published_at": "2020-10-31T22:29:33Z",
+      "published_day": "2020-10-31",
+      "release": "0.51",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.51"
+    },
+    {
+      "published_at": "2020-10-30T17:57:53Z",
+      "published_day": "2020-10-30",
+      "release": "0.51a2",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.51a2"
+    },
+    {
+      "published_at": "2020-10-30T05:37:34Z",
+      "published_day": "2020-10-30",
+      "release": "0.51a1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.51a1"
+    },
+    {
+      "published_at": "2020-10-20T05:33:01Z",
+      "published_day": "2020-10-20",
+      "release": "0.51a0",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.51a0"
+    },
+    {
+      "published_at": "2020-10-10T03:59:18Z",
+      "published_day": "2020-10-10",
+      "release": "0.50.2",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.50.2"
+    },
+    {
+      "published_at": "2020-10-10T00:44:23Z",
+      "published_day": "2020-10-10",
+      "release": "0.50.1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.50.1"
+    },
+    {
+      "published_at": "2020-10-09T17:58:27Z",
+      "published_day": "2020-10-09",
+      "release": "0.50",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.50"
+    },
+    {
+      "published_at": "2020-10-06T20:52:49Z",
+      "published_day": "2020-10-06",
+      "release": "0.50a1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.50a1"
+    },
+    {
+      "published_at": "2020-10-01T23:35:54Z",
+      "published_day": "2020-10-01",
+      "release": "0.50a0",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.50a0"
+    },
+    {
+      "published_at": "2020-09-15T20:21:16Z",
+      "published_day": "2020-09-15",
+      "release": "0.49.1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.49.1"
+    },
+    {
+      "published_at": "2020-09-14T21:40:11Z",
+      "published_day": "2020-09-14",
+      "release": "0.49",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.49"
+    },
+    {
+      "published_at": "2020-09-14T02:48:19Z",
+      "published_day": "2020-09-14",
+      "release": "0.49a1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.49a1"
+    },
+    {
+      "published_at": "2020-08-28T23:18:09Z",
+      "published_day": "2020-08-28",
+      "release": "0.49a0",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.49a0"
+    },
+    {
+      "published_at": "2020-08-16T18:58:34Z",
+      "published_day": "2020-08-16",
+      "release": "0.48",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.48"
+    },
+    {
+      "published_at": "2020-08-15T21:03:58Z",
+      "published_day": "2020-08-15",
+      "release": "0.47.3",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.47.3"
+    },
+    {
+      "published_at": "2020-08-12T20:55:28Z",
+      "published_day": "2020-08-12",
+      "release": "0.47.2",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.47.2"
+    },
+    {
+      "published_at": "2020-08-12T02:38:00Z",
+      "published_day": "2020-08-12",
+      "release": "0.47.1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.47.1"
+    },
+    {
+      "published_at": "2020-08-12T00:44:52Z",
+      "published_day": "2020-08-12",
+      "release": "0.47",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.47"
+    },
+    {
+      "published_at": "2020-08-09T16:10:47Z",
+      "published_day": "2020-08-09",
+      "release": "0.46",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.46"
+    },
+    {
+      "published_at": "2020-07-01T21:46:07Z",
+      "published_day": "2020-07-01",
+      "release": "0.45",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.45"
+    },
+    {
+      "published_at": "2020-07-01T04:27:08Z",
+      "published_day": "2020-07-01",
+      "release": "0.45a5",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.45a5"
+    },
+    {
+      "published_at": "2020-06-29T02:33:02Z",
+      "published_day": "2020-06-29",
+      "release": "0.45a4",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.45a4"
+    },
+    {
+      "published_at": "2020-06-28T03:27:12Z",
+      "published_day": "2020-06-28",
+      "release": "0.45a3",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.45a3"
+    },
+    {
+      "published_at": "2020-06-24T04:32:12Z",
+      "published_day": "2020-06-24",
+      "release": "0.45a2",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.45a2"
+    },
+    {
+      "published_at": "2020-06-19T00:02:29Z",
+      "published_day": "2020-06-19",
+      "release": "0.45a1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.45a1"
+    },
+    {
+      "published_at": "2020-06-18T21:14:00Z",
+      "published_day": "2020-06-18",
+      "release": "0.45a0",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.45a0"
+    },
+    {
+      "published_at": "2020-06-12T07:10:38Z",
+      "published_day": "2020-06-12",
+      "release": "0.44",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.44"
+    },
+    {
+      "published_at": "2020-05-28T14:39:18Z",
+      "published_day": "2020-05-28",
+      "release": "0.43",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.43"
+    },
+    {
+      "published_at": "2020-05-08T17:56:36Z",
+      "published_day": "2020-05-08",
+      "release": "0.42",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.42"
+    },
+    {
+      "published_at": "2020-05-06T18:30:03Z",
+      "published_day": "2020-05-06",
+      "release": "0.41",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.41"
+    },
+    {
+      "published_at": "2020-04-22T04:06:51Z",
+      "published_day": "2020-04-22",
+      "release": "0.40",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.40"
+    },
+    {
+      "published_at": "2020-03-25T04:11:35Z",
+      "published_day": "2020-03-25",
+      "release": "0.39",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.39"
+    },
+    {
+      "published_at": "2020-03-08T23:42:36Z",
+      "published_day": "2020-03-08",
+      "release": "0.38",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.38"
+    },
+    {
+      "published_at": "2020-03-03T03:46:17Z",
+      "published_day": "2020-03-03",
+      "release": "Datasette 0.37.1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.37.1"
+    },
+    {
+      "published_at": "2020-02-26T03:44:07Z",
+      "published_day": "2020-02-26",
+      "release": "Datasette 0.37",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.37"
+    },
+    {
+      "published_at": "2020-02-22T03:24:50Z",
+      "published_day": "2020-02-22",
+      "release": "Datasette 0.36",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.36"
+    },
+    {
+      "published_at": "2020-02-05T02:32:34Z",
+      "published_day": "2020-02-05",
+      "release": "Datasette 0.35",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.35"
+    },
+    {
+      "published_at": "2020-01-30T00:29:21Z",
+      "published_day": "2020-01-30",
+      "release": "Datasette 0.34",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.34"
+    },
+    {
+      "published_at": "2019-12-22T16:43:31Z",
+      "published_day": "2019-12-22",
+      "release": "Datasette 0.33",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.33"
+    },
+    {
+      "published_at": "2019-11-14T23:42:14Z",
+      "published_day": "2019-11-14",
+      "release": "Datasette 0.32",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.32"
+    },
+    {
+      "published_at": "2019-11-13T17:38:59Z",
+      "published_day": "2019-11-13",
+      "release": "0.31.2",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.31.2"
+    },
+    {
+      "published_at": "2019-11-13T02:40:53Z",
+      "published_day": "2019-11-13",
+      "release": "0.31.1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.31.1"
+    },
+    {
+      "published_at": "2019-11-13T02:16:15Z",
+      "published_day": "2019-11-13",
+      "release": "Datasette 0.31",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.31"
+    },
+    {
+      "published_at": "2019-11-02T23:33:13Z",
+      "published_day": "2019-11-02",
+      "release": "0.30.2",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.30.2"
+    },
+    {
+      "published_at": "2019-11-02T00:06:02Z",
+      "published_day": "2019-11-02",
+      "release": "0.30.1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.30.1"
+    },
+    {
+      "published_at": "2019-10-30T18:51:30Z",
+      "published_day": "2019-10-30",
+      "release": "0.30",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.30"
+    },
+    {
+      "published_at": "2019-10-18T05:24:54Z",
+      "published_day": "2019-10-18",
+      "release": "0.29.3",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.29.3"
+    },
+    {
+      "published_at": "2019-09-03T00:33:35Z",
+      "published_day": "2019-09-03",
+      "release": "0.29.2",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.29.2"
+    },
+    {
+      "published_at": "2019-07-14T01:43:44Z",
+      "published_day": "2019-07-14",
+      "release": "0.29.1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.29.1"
+    },
+    {
+      "published_at": "2019-07-08T03:43:13Z",
+      "published_day": "2019-07-08",
+      "release": "Datasette 0.29",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.29"
+    },
+    {
+      "published_at": "2019-05-19T21:42:28Z",
+      "published_day": "2019-05-19",
+      "release": "Datasette 0.28",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.28"
+    },
+    {
+      "published_at": "2019-02-06T05:10:20Z",
+      "published_day": "2019-02-06",
+      "release": "Datasette 0.27",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.27"
+    },
+    {
+      "published_at": "2019-01-28T01:50:45Z",
+      "published_day": "2019-01-28",
+      "release": "Datasette 0.26.1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.26.1"
+    },
+    {
+      "published_at": "2019-01-10T21:41:00Z",
+      "published_day": "2019-01-10",
+      "release": "Datasette 0.26",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.26"
+    },
+    {
+      "published_at": "2018-12-16T21:45:39Z",
+      "published_day": "2018-12-16",
+      "release": "Datasette 0.25.2",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.25.2"
+    },
+    {
+      "published_at": "2018-12-16T21:44:27Z",
+      "published_day": "2018-12-16",
+      "release": "Datasette 0.25.1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.25.1"
+    },
+    {
+      "published_at": "2018-09-19T18:27:21Z",
+      "published_day": "2018-09-19",
+      "release": "Datasette 0.25",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.25"
+    },
+    {
+      "published_at": "2018-07-24T16:51:29Z",
+      "published_day": "2018-07-24",
+      "release": "Datasette 0.24",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.24"
+    },
+    {
+      "published_at": "2018-07-08T05:41:38Z",
+      "published_day": "2018-07-08",
+      "release": "Datasette 0.23.2",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.23.2"
+    },
+    {
+      "published_at": "2018-06-21T16:02:44Z",
+      "published_day": "2018-06-21",
+      "release": "Datasette 0.23.1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.23.1"
+    },
+    {
+      "published_at": "2018-06-18T15:28:37Z",
+      "published_day": "2018-06-18",
+      "release": "Datasette 0.23: CSV, SpatiaLite and more",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.23"
+    },
+    {
+      "published_at": "2018-05-23T14:04:17Z",
+      "published_day": "2018-05-23",
+      "release": "Datasette 0.22.1",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.22.1"
+    },
+    {
+      "published_at": "2018-05-20T23:44:19Z",
+      "published_day": "2018-05-20",
+      "release": "Datasette 0.22: Datasette Facets",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.22"
+    },
+    {
+      "published_at": "2018-05-05T23:21:33Z",
+      "published_day": "2018-05-05",
+      "release": "Datasette 0.21: New _shape=, new _size=, search within columns",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.21"
+    },
+    {
+      "published_at": "2018-04-20T14:41:14Z",
+      "published_day": "2018-04-20",
+      "release": "Datasette 0.20: static assets and templates for plugins",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.20"
+    },
+    {
+      "published_at": "2018-04-17T02:21:51Z",
+      "published_day": "2018-04-17",
+      "release": "Datasette 0.19: plugins preview",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.19"
+    },
+    {
+      "published_at": "2018-04-14T15:45:11Z",
+      "published_day": "2018-04-14",
+      "release": "Datasette 0.18: units",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.18"
+    },
+    {
+      "published_at": "2018-04-13T21:10:53Z",
+      "published_day": "2018-04-13",
+      "release": "Datasette 0.16: sort on mobile, better error handling",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.16"
+    },
+    {
+      "published_at": "2018-04-09T15:55:29Z",
+      "published_day": "2018-04-09",
+      "release": "Datasette 0.15: sort by column",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.15"
+    },
+    {
+      "published_at": "2017-12-10T01:41:14Z",
+      "published_day": "2017-12-10",
+      "release": "Datasette 0.14: customization edition",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.14"
+    },
+    {
+      "published_at": "2017-11-25T03:44:46Z",
+      "published_day": "2017-11-25",
+      "release": "Datasette 0.13: foreign key, search and filters",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.13"
+    },
+    {
+      "published_at": "2017-11-16T16:01:35Z",
+      "published_day": "2017-11-16",
+      "release": "Datasette 0.12",
+      "url": "https://github.com/simonw/datasette/releases/tag/0.12"
+    }
+  ],
+  "repo": "datasette",
+  "total_releases": 166,
+  "url": "https://github.com/simonw/datasette"
+}

--- a/repos/simonw/datasette/releases.json
+++ b/repos/simonw/datasette/releases.json
@@ -3,996 +3,1162 @@
   "owner": "simonw",
   "releases": [
     {
+      "author": "simonw",
       "published_at": "2026-06-16T21:31:24Z",
       "published_day": "2026-06-16",
       "release": "1.0a34",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a34"
     },
     {
+      "author": "simonw",
       "published_at": "2026-06-11T15:26:49Z",
       "published_day": "2026-06-11",
       "release": "1.0a33",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a33"
     },
     {
+      "author": "simonw",
       "published_at": "2026-05-31T23:23:38Z",
       "published_day": "2026-05-31",
       "release": "1.0a32",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a32"
     },
     {
+      "author": "simonw",
       "published_at": "2026-05-29T03:32:02Z",
       "published_day": "2026-05-29",
       "release": "1.0a31",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a31"
     },
     {
+      "author": "simonw",
       "published_at": "2026-05-24T21:20:14Z",
       "published_day": "2026-05-24",
       "release": "1.0a30",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a30"
     },
     {
+      "author": "simonw",
       "published_at": "2026-05-12T23:41:06Z",
       "published_day": "2026-05-12",
       "release": "1.0a29",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a29"
     },
     {
+      "author": "simonw",
       "published_at": "2026-04-17T04:01:56Z",
       "published_day": "2026-04-17",
       "release": "1.0a28",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a28"
     },
     {
+      "author": "simonw",
       "published_at": "2026-04-15T23:16:34Z",
       "published_day": "2026-04-15",
       "release": "1.0a27",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a27"
     },
     {
+      "author": "simonw",
       "published_at": "2026-03-18T22:16:19Z",
       "published_day": "2026-03-18",
       "release": "1.0a26",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a26"
     },
     {
-      "published_at": "2026-02-26T00:50:43Z",
+      "author": "simonw",
+      "published_at": "2026-02-26T01:01:45Z",
       "published_day": "2026-02-26",
       "release": "1.0a25",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a25"
     },
     {
+      "author": "simonw",
       "published_at": "2026-01-29T17:04:33Z",
       "published_day": "2026-01-29",
       "release": "1.0a24",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a24"
     },
     {
+      "author": "simonw",
       "published_at": "2025-12-03T03:21:50Z",
       "published_day": "2025-12-03",
       "release": "1.0a23",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a23"
     },
     {
+      "author": "simonw",
       "published_at": "2025-11-13T18:42:02Z",
       "published_day": "2025-11-13",
       "release": "1.0a22",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a22"
     },
     {
+      "author": "simonw",
       "published_at": "2025-11-05T21:55:15Z",
       "published_day": "2025-11-05",
       "release": "1.0a21",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a21"
     },
     {
+      "author": "simonw",
       "published_at": "2025-11-05T18:20:30Z",
       "published_day": "2025-11-05",
       "release": "0.65.2",
       "url": "https://github.com/simonw/datasette/releases/tag/0.65.2"
     },
     {
+      "author": "simonw",
       "published_at": "2025-11-03T22:50:28Z",
       "published_day": "2025-11-03",
       "release": "1.0a20",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a20"
     },
     {
+      "author": "simonw",
       "published_at": "2025-04-22T05:39:37Z",
       "published_day": "2025-04-22",
       "release": "1.0a19",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a19"
     },
     {
+      "author": "simonw",
       "published_at": "2025-04-17T05:18:09Z",
       "published_day": "2025-04-17",
       "release": "1.0a18",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a18"
     },
     {
+      "author": "simonw",
       "published_at": "2025-02-06T19:14:10Z",
       "published_day": "2025-02-06",
       "release": "1.0a17",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a17"
     },
     {
+      "author": "simonw",
       "published_at": "2024-11-29T01:13:13Z",
       "published_day": "2024-11-29",
       "release": "0.65.1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.65.1"
     },
     {
+      "author": "simonw",
       "published_at": "2024-10-07T17:38:03Z",
       "published_day": "2024-10-07",
       "release": "0.65",
       "url": "https://github.com/simonw/datasette/releases/tag/0.65"
     },
     {
+      "author": "simonw",
       "published_at": "2024-09-06T03:58:44Z",
       "published_day": "2024-09-06",
       "release": "1.0a16",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a16"
     },
     {
+      "author": "simonw",
       "published_at": "2024-08-16T05:05:47Z",
       "published_day": "2024-08-16",
       "release": "1.0a15",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a15"
     },
     {
+      "author": "simonw",
       "published_at": "2024-08-05T21:31:43Z",
       "published_day": "2024-08-05",
       "release": "1.0a14",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a14"
     },
     {
+      "author": "simonw",
       "published_at": "2024-06-21T23:42:18Z",
       "published_day": "2024-06-21",
       "release": "0.64.8",
       "url": "https://github.com/simonw/datasette/releases/tag/0.64.8"
     },
     {
+      "author": "simonw",
       "published_at": "2024-06-12T23:09:31Z",
       "published_day": "2024-06-12",
       "release": "0.64.7",
       "url": "https://github.com/simonw/datasette/releases/tag/0.64.7"
     },
     {
+      "author": "simonw",
       "published_at": "2024-03-13T02:14:36Z",
       "published_day": "2024-03-13",
       "release": "1.0a13",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a13"
     },
     {
+      "author": "simonw",
       "published_at": "2024-02-29T22:36:42Z",
       "published_day": "2024-02-29",
       "release": "1.0a12",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a12"
     },
     {
+      "author": "simonw",
       "published_at": "2024-02-19T22:52:29Z",
       "published_day": "2024-02-19",
       "release": "1.0a11",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a11"
     },
     {
+      "author": "simonw",
       "published_at": "2024-02-18T05:04:08Z",
       "published_day": "2024-02-18",
       "release": "1.0a10",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a10"
     },
     {
+      "author": "simonw",
       "published_at": "2024-02-16T22:39:38Z",
       "published_day": "2024-02-16",
       "release": "1.0a9",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a9"
     },
     {
+      "author": "simonw",
       "published_at": "2024-02-07T16:37:33Z",
       "published_day": "2024-02-07",
       "release": "1.0a8",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a8"
     },
     {
+      "author": "simonw",
       "published_at": "2023-12-22T23:19:30Z",
       "published_day": "2023-12-22",
       "release": "0.64.6",
       "url": "https://github.com/simonw/datasette/releases/tag/0.64.6"
     },
     {
+      "author": "simonw",
       "published_at": "2023-10-08T16:05:20Z",
       "published_day": "2023-10-08",
       "release": "0.64.5",
       "url": "https://github.com/simonw/datasette/releases/tag/0.64.5"
     },
     {
+      "author": "simonw",
       "published_at": "2023-09-21T22:13:27Z",
       "published_day": "2023-09-21",
       "release": "1.0a7",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a7"
     },
     {
+      "author": "simonw",
       "published_at": "2023-09-21T19:43:54Z",
       "published_day": "2023-09-21",
       "release": "0.64.4",
       "url": "https://github.com/simonw/datasette/releases/tag/0.64.4"
     },
     {
+      "author": "simonw",
       "published_at": "2023-09-08T04:45:12Z",
       "published_day": "2023-09-08",
       "release": "1.0a6",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a6"
     },
     {
+      "author": "simonw",
       "published_at": "2023-08-29T17:19:35Z",
       "published_day": "2023-08-29",
       "release": "1.0a5",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a5"
     },
     {
+      "author": "simonw",
       "published_at": "2023-08-22T17:13:26Z",
       "published_day": "2023-08-22",
       "release": "1.0a4",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a4"
     },
     {
+      "author": "simonw",
       "published_at": "2023-08-09T19:17:26Z",
       "published_day": "2023-08-09",
       "release": "1.0a3",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a3"
     },
     {
+      "author": "simonw",
       "published_at": "2023-04-27T15:00:27Z",
       "published_day": "2023-04-27",
       "release": "0.64.3",
       "url": "https://github.com/simonw/datasette/releases/tag/0.64.3"
     },
     {
+      "author": "simonw",
       "published_at": "2023-03-08T20:46:27Z",
       "published_day": "2023-03-08",
       "release": "0.64.2",
       "url": "https://github.com/simonw/datasette/releases/tag/0.64.2"
     },
     {
+      "author": "simonw",
       "published_at": "2023-01-11T18:27:56Z",
       "published_day": "2023-01-11",
       "release": "0.64.1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.64.1"
     },
     {
+      "author": "simonw",
       "published_at": "2023-01-09T16:49:04Z",
       "published_day": "2023-01-09",
       "release": "0.64",
       "url": "https://github.com/simonw/datasette/releases/tag/0.64"
     },
     {
+      "author": "simonw",
       "published_at": "2022-12-18T03:10:52Z",
       "published_day": "2022-12-18",
       "release": "0.63.3",
       "url": "https://github.com/simonw/datasette/releases/tag/0.63.3"
     },
     {
+      "author": "simonw",
       "published_at": "2022-12-15T02:03:59Z",
       "published_day": "2022-12-15",
       "release": "1.0a2",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a2"
     },
     {
+      "author": "simonw",
       "published_at": "2022-12-01T21:42:45Z",
       "published_day": "2022-12-01",
       "release": "1.0a1",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a1"
     },
     {
+      "author": "simonw",
       "published_at": "2022-11-29T19:58:55Z",
       "published_day": "2022-11-29",
       "release": "1.0a0",
       "url": "https://github.com/simonw/datasette/releases/tag/1.0a0"
     },
     {
+      "author": "simonw",
       "published_at": "2022-11-19T00:58:27Z",
       "published_day": "2022-11-19",
       "release": "0.63.2",
       "url": "https://github.com/simonw/datasette/releases/tag/0.63.2"
     },
     {
+      "author": "simonw",
       "published_at": "2022-11-11T07:02:36Z",
       "published_day": "2022-11-11",
       "release": "0.63.1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.63.1"
     },
     {
+      "author": "simonw",
       "published_at": "2022-10-27T22:13:32Z",
       "published_day": "2022-10-27",
       "release": "0.63",
       "url": "https://github.com/simonw/datasette/releases/tag/0.63"
     },
     {
+      "author": "simonw",
       "published_at": "2022-10-24T03:11:47Z",
       "published_day": "2022-10-24",
       "release": "0.63a1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.63a1"
     },
     {
+      "author": "simonw",
       "published_at": "2022-09-26T21:56:30Z",
       "published_day": "2022-09-26",
       "release": "0.63a0",
       "url": "https://github.com/simonw/datasette/releases/tag/0.63a0"
     },
     {
+      "author": "simonw",
       "published_at": "2022-08-14T17:43:05Z",
       "published_day": "2022-08-14",
       "release": "0.62",
       "url": "https://github.com/simonw/datasette/releases/tag/0.62"
     },
     {
+      "author": "simonw",
       "published_at": "2022-07-18T01:09:05Z",
       "published_day": "2022-07-18",
       "release": "0.62a1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.62a1"
     },
     {
+      "author": "simonw",
       "published_at": "2022-05-02T21:39:52Z",
       "published_day": "2022-05-02",
       "release": "0.62a0",
       "url": "https://github.com/simonw/datasette/releases/tag/0.62a0"
     },
     {
+      "author": "simonw",
       "published_at": "2022-03-23T20:31:09Z",
       "published_day": "2022-03-23",
       "release": "0.61.1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.61.1"
     },
     {
+      "author": "simonw",
       "published_at": "2022-03-23T18:14:36Z",
       "published_day": "2022-03-23",
       "release": "0.61",
       "url": "https://github.com/simonw/datasette/releases/tag/0.61"
     },
     {
+      "author": "simonw",
       "published_at": "2022-03-20T01:16:41Z",
       "published_day": "2022-03-20",
       "release": "0.61a0",
       "url": "https://github.com/simonw/datasette/releases/tag/0.61a0"
     },
     {
+      "author": "simonw",
       "published_at": "2022-02-07T23:49:38Z",
       "published_day": "2022-02-07",
       "release": "0.60.2",
       "url": "https://github.com/simonw/datasette/releases/tag/0.60.2"
     },
     {
+      "author": "simonw",
       "published_at": "2022-01-21T02:12:54Z",
       "published_day": "2022-01-21",
       "release": "0.60.1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.60.1"
     },
     {
+      "author": "simonw",
       "published_at": "2022-01-14T01:41:28Z",
       "published_day": "2022-01-14",
       "release": "0.60",
       "url": "https://github.com/simonw/datasette/releases/tag/0.60"
     },
     {
+      "author": "simonw",
       "published_at": "2021-12-19T22:11:16Z",
       "published_day": "2021-12-19",
       "release": "0.60a1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.60a1"
     },
     {
+      "author": "simonw",
       "published_at": "2021-12-17T19:15:38Z",
       "published_day": "2021-12-17",
       "release": "0.60a0",
       "url": "https://github.com/simonw/datasette/releases/tag/0.60a0"
     },
     {
+      "author": "simonw",
       "published_at": "2021-11-30T06:50:48Z",
       "published_day": "2021-11-30",
       "release": "0.59.4",
       "url": "https://github.com/simonw/datasette/releases/tag/0.59.4"
     },
     {
+      "author": "simonw",
       "published_at": "2021-11-20T23:41:33Z",
       "published_day": "2021-11-20",
       "release": "0.59.3",
       "url": "https://github.com/simonw/datasette/releases/tag/0.59.3"
     },
     {
+      "author": "simonw",
       "published_at": "2021-11-14T05:43:09Z",
       "published_day": "2021-11-14",
       "release": "0.59.2",
       "url": "https://github.com/simonw/datasette/releases/tag/0.59.2"
     },
     {
+      "author": "simonw",
       "published_at": "2021-10-24T22:32:25Z",
       "published_day": "2021-10-24",
       "release": "0.59.1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.59.1"
     },
     {
+      "author": "simonw",
       "published_at": "2021-10-14T19:31:56Z",
       "published_day": "2021-10-14",
       "release": "0.59",
       "url": "https://github.com/simonw/datasette/releases/tag/0.59"
     },
     {
+      "author": "simonw",
       "published_at": "2021-08-28T01:57:38Z",
       "published_day": "2021-08-28",
       "release": "0.59a2",
       "url": "https://github.com/simonw/datasette/releases/tag/0.59a2"
     },
     {
+      "author": "simonw",
       "published_at": "2021-08-09T01:14:06Z",
       "published_day": "2021-08-09",
       "release": "0.59a1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.59a1"
     },
     {
+      "author": "simonw",
       "published_at": "2021-08-07T05:42:25Z",
       "published_day": "2021-08-07",
       "release": "0.59a0",
       "url": "https://github.com/simonw/datasette/releases/tag/0.59a0"
     },
     {
+      "author": "simonw",
       "published_at": "2021-07-16T19:51:15Z",
       "published_day": "2021-07-16",
       "release": "0.58.1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.58.1"
     },
     {
+      "author": "simonw",
       "published_at": "2021-07-15T00:37:57Z",
       "published_day": "2021-07-15",
       "release": "0.58",
       "url": "https://github.com/simonw/datasette/releases/tag/0.58"
     },
     {
+      "author": "simonw",
       "published_at": "2021-06-24T16:29:09Z",
       "published_day": "2021-06-24",
       "release": "0.58a1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.58a1"
     },
     {
+      "author": "simonw",
       "published_at": "2021-06-10T04:52:45Z",
       "published_day": "2021-06-10",
       "release": "0.58a0",
       "url": "https://github.com/simonw/datasette/releases/tag/0.58a0"
     },
     {
+      "author": "simonw",
       "published_at": "2021-06-08T16:28:31Z",
       "published_day": "2021-06-08",
       "release": "0.57.1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.57.1"
     },
     {
+      "author": "simonw",
       "published_at": "2021-06-05T22:11:18Z",
       "published_day": "2021-06-05",
       "release": "0.57",
       "url": "https://github.com/simonw/datasette/releases/tag/0.57"
     },
     {
+      "author": "simonw",
       "published_at": "2021-06-05T22:00:01Z",
       "published_day": "2021-06-05",
       "release": "0.56.1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.56.1"
     },
     {
+      "author": "simonw",
       "published_at": "2021-05-27T16:58:41Z",
       "published_day": "2021-05-27",
       "release": "0.57a1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.57a1"
     },
     {
+      "author": "simonw",
       "published_at": "2021-05-23T00:46:44Z",
       "published_day": "2021-05-23",
       "release": "0.57a0",
       "url": "https://github.com/simonw/datasette/releases/tag/0.57a0"
     },
     {
+      "author": "simonw",
       "published_at": "2021-03-29T00:43:36Z",
       "published_day": "2021-03-29",
       "release": "0.56",
       "url": "https://github.com/simonw/datasette/releases/tag/0.56"
     },
     {
+      "author": "simonw",
       "published_at": "2021-02-19T02:02:29Z",
       "published_day": "2021-02-19",
       "release": "0.55",
       "url": "https://github.com/simonw/datasette/releases/tag/0.55"
     },
     {
+      "author": "simonw",
       "published_at": "2021-02-02T21:30:12Z",
       "published_day": "2021-02-02",
       "release": "0.54.1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.54.1"
     },
     {
+      "author": "simonw",
       "published_at": "2021-01-25T17:36:30Z",
       "published_day": "2021-01-25",
       "release": "0.54",
       "url": "https://github.com/simonw/datasette/releases/tag/0.54"
     },
     {
+      "author": "simonw",
       "published_at": "2021-01-19T20:51:13Z",
       "published_day": "2021-01-19",
       "release": "0.54a0",
       "url": "https://github.com/simonw/datasette/releases/tag/0.54a0"
     },
     {
+      "author": "simonw",
       "published_at": "2020-12-11T01:46:44Z",
       "published_day": "2020-12-11",
       "release": "0.53",
       "url": "https://github.com/simonw/datasette/releases/tag/0.53"
     },
     {
+      "author": "simonw",
       "published_at": "2020-12-09T20:10:23Z",
       "published_day": "2020-12-09",
       "release": "0.52.5",
       "url": "https://github.com/simonw/datasette/releases/tag/0.52.5"
     },
     {
+      "author": "simonw",
       "published_at": "2020-12-05T19:42:57Z",
       "published_day": "2020-12-05",
       "release": "0.52.4",
       "url": "https://github.com/simonw/datasette/releases/tag/0.52.4"
     },
     {
+      "author": "simonw",
       "published_at": "2020-12-03T19:08:29Z",
       "published_day": "2020-12-03",
       "release": "0.52.3",
       "url": "https://github.com/simonw/datasette/releases/tag/0.52.3"
     },
     {
+      "author": "simonw",
       "published_at": "2020-12-03T00:58:43Z",
       "published_day": "2020-12-03",
       "release": "0.52.2",
       "url": "https://github.com/simonw/datasette/releases/tag/0.52.2"
     },
     {
+      "author": "simonw",
       "published_at": "2020-11-29T19:39:52Z",
       "published_day": "2020-11-29",
       "release": "0.52.1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.52.1"
     },
     {
+      "author": "simonw",
       "published_at": "2020-11-28T23:57:12Z",
       "published_day": "2020-11-28",
       "release": "0.52",
       "url": "https://github.com/simonw/datasette/releases/tag/0.52"
     },
     {
+      "author": "simonw",
       "published_at": "2020-11-01T03:34:36Z",
       "published_day": "2020-11-01",
       "release": "0.51.1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.51.1"
     },
     {
+      "author": "simonw",
       "published_at": "2020-10-31T22:29:33Z",
       "published_day": "2020-10-31",
       "release": "0.51",
       "url": "https://github.com/simonw/datasette/releases/tag/0.51"
     },
     {
+      "author": "simonw",
       "published_at": "2020-10-30T17:57:53Z",
       "published_day": "2020-10-30",
       "release": "0.51a2",
       "url": "https://github.com/simonw/datasette/releases/tag/0.51a2"
     },
     {
+      "author": "simonw",
       "published_at": "2020-10-30T05:37:34Z",
       "published_day": "2020-10-30",
       "release": "0.51a1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.51a1"
     },
     {
+      "author": "simonw",
       "published_at": "2020-10-20T05:33:01Z",
       "published_day": "2020-10-20",
       "release": "0.51a0",
       "url": "https://github.com/simonw/datasette/releases/tag/0.51a0"
     },
     {
+      "author": "simonw",
       "published_at": "2020-10-10T03:59:18Z",
       "published_day": "2020-10-10",
       "release": "0.50.2",
       "url": "https://github.com/simonw/datasette/releases/tag/0.50.2"
     },
     {
+      "author": "simonw",
       "published_at": "2020-10-10T00:44:23Z",
       "published_day": "2020-10-10",
       "release": "0.50.1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.50.1"
     },
     {
+      "author": "simonw",
       "published_at": "2020-10-09T17:58:27Z",
       "published_day": "2020-10-09",
       "release": "0.50",
       "url": "https://github.com/simonw/datasette/releases/tag/0.50"
     },
     {
+      "author": "simonw",
       "published_at": "2020-10-06T20:52:49Z",
       "published_day": "2020-10-06",
       "release": "0.50a1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.50a1"
     },
     {
+      "author": "simonw",
       "published_at": "2020-10-01T23:35:54Z",
       "published_day": "2020-10-01",
       "release": "0.50a0",
       "url": "https://github.com/simonw/datasette/releases/tag/0.50a0"
     },
     {
+      "author": "simonw",
       "published_at": "2020-09-15T20:21:16Z",
       "published_day": "2020-09-15",
       "release": "0.49.1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.49.1"
     },
     {
+      "author": "simonw",
       "published_at": "2020-09-14T21:40:11Z",
       "published_day": "2020-09-14",
       "release": "0.49",
       "url": "https://github.com/simonw/datasette/releases/tag/0.49"
     },
     {
+      "author": "simonw",
       "published_at": "2020-09-14T02:48:19Z",
       "published_day": "2020-09-14",
       "release": "0.49a1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.49a1"
     },
     {
+      "author": "simonw",
       "published_at": "2020-08-28T23:18:09Z",
       "published_day": "2020-08-28",
       "release": "0.49a0",
       "url": "https://github.com/simonw/datasette/releases/tag/0.49a0"
     },
     {
+      "author": "simonw",
       "published_at": "2020-08-16T18:58:34Z",
       "published_day": "2020-08-16",
       "release": "0.48",
       "url": "https://github.com/simonw/datasette/releases/tag/0.48"
     },
     {
+      "author": "simonw",
       "published_at": "2020-08-15T21:03:58Z",
       "published_day": "2020-08-15",
       "release": "0.47.3",
       "url": "https://github.com/simonw/datasette/releases/tag/0.47.3"
     },
     {
+      "author": "simonw",
       "published_at": "2020-08-12T20:55:28Z",
       "published_day": "2020-08-12",
       "release": "0.47.2",
       "url": "https://github.com/simonw/datasette/releases/tag/0.47.2"
     },
     {
+      "author": "simonw",
       "published_at": "2020-08-12T02:38:00Z",
       "published_day": "2020-08-12",
       "release": "0.47.1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.47.1"
     },
     {
+      "author": "simonw",
       "published_at": "2020-08-12T00:44:52Z",
       "published_day": "2020-08-12",
       "release": "0.47",
       "url": "https://github.com/simonw/datasette/releases/tag/0.47"
     },
     {
+      "author": "simonw",
       "published_at": "2020-08-09T16:10:47Z",
       "published_day": "2020-08-09",
       "release": "0.46",
       "url": "https://github.com/simonw/datasette/releases/tag/0.46"
     },
     {
+      "author": "simonw",
       "published_at": "2020-07-01T21:46:07Z",
       "published_day": "2020-07-01",
       "release": "0.45",
       "url": "https://github.com/simonw/datasette/releases/tag/0.45"
     },
     {
+      "author": "simonw",
       "published_at": "2020-07-01T04:27:08Z",
       "published_day": "2020-07-01",
       "release": "0.45a5",
       "url": "https://github.com/simonw/datasette/releases/tag/0.45a5"
     },
     {
+      "author": "simonw",
       "published_at": "2020-06-29T02:33:02Z",
       "published_day": "2020-06-29",
       "release": "0.45a4",
       "url": "https://github.com/simonw/datasette/releases/tag/0.45a4"
     },
     {
+      "author": "simonw",
       "published_at": "2020-06-28T03:27:12Z",
       "published_day": "2020-06-28",
       "release": "0.45a3",
       "url": "https://github.com/simonw/datasette/releases/tag/0.45a3"
     },
     {
+      "author": "simonw",
       "published_at": "2020-06-24T04:32:12Z",
       "published_day": "2020-06-24",
       "release": "0.45a2",
       "url": "https://github.com/simonw/datasette/releases/tag/0.45a2"
     },
     {
+      "author": "simonw",
       "published_at": "2020-06-19T00:02:29Z",
       "published_day": "2020-06-19",
       "release": "0.45a1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.45a1"
     },
     {
+      "author": "simonw",
       "published_at": "2020-06-18T21:14:00Z",
       "published_day": "2020-06-18",
       "release": "0.45a0",
       "url": "https://github.com/simonw/datasette/releases/tag/0.45a0"
     },
     {
+      "author": "simonw",
       "published_at": "2020-06-12T07:10:38Z",
       "published_day": "2020-06-12",
       "release": "0.44",
       "url": "https://github.com/simonw/datasette/releases/tag/0.44"
     },
     {
+      "author": "simonw",
       "published_at": "2020-05-28T14:39:18Z",
       "published_day": "2020-05-28",
       "release": "0.43",
       "url": "https://github.com/simonw/datasette/releases/tag/0.43"
     },
     {
+      "author": "simonw",
       "published_at": "2020-05-08T17:56:36Z",
       "published_day": "2020-05-08",
       "release": "0.42",
       "url": "https://github.com/simonw/datasette/releases/tag/0.42"
     },
     {
+      "author": "simonw",
       "published_at": "2020-05-06T18:30:03Z",
       "published_day": "2020-05-06",
       "release": "0.41",
       "url": "https://github.com/simonw/datasette/releases/tag/0.41"
     },
     {
+      "author": "simonw",
       "published_at": "2020-04-22T04:06:51Z",
       "published_day": "2020-04-22",
       "release": "0.40",
       "url": "https://github.com/simonw/datasette/releases/tag/0.40"
     },
     {
+      "author": "simonw",
       "published_at": "2020-03-25T04:11:35Z",
       "published_day": "2020-03-25",
       "release": "0.39",
       "url": "https://github.com/simonw/datasette/releases/tag/0.39"
     },
     {
+      "author": "simonw",
       "published_at": "2020-03-08T23:42:36Z",
       "published_day": "2020-03-08",
       "release": "0.38",
       "url": "https://github.com/simonw/datasette/releases/tag/0.38"
     },
     {
+      "author": "simonw",
       "published_at": "2020-03-03T03:46:17Z",
       "published_day": "2020-03-03",
       "release": "Datasette 0.37.1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.37.1"
     },
     {
+      "author": "simonw",
       "published_at": "2020-02-26T03:44:07Z",
       "published_day": "2020-02-26",
       "release": "Datasette 0.37",
       "url": "https://github.com/simonw/datasette/releases/tag/0.37"
     },
     {
+      "author": "simonw",
       "published_at": "2020-02-22T03:24:50Z",
       "published_day": "2020-02-22",
       "release": "Datasette 0.36",
       "url": "https://github.com/simonw/datasette/releases/tag/0.36"
     },
     {
+      "author": "simonw",
       "published_at": "2020-02-05T02:32:34Z",
       "published_day": "2020-02-05",
       "release": "Datasette 0.35",
       "url": "https://github.com/simonw/datasette/releases/tag/0.35"
     },
     {
+      "author": "simonw",
       "published_at": "2020-01-30T00:29:21Z",
       "published_day": "2020-01-30",
       "release": "Datasette 0.34",
       "url": "https://github.com/simonw/datasette/releases/tag/0.34"
     },
     {
+      "author": "simonw",
       "published_at": "2019-12-22T16:43:31Z",
       "published_day": "2019-12-22",
       "release": "Datasette 0.33",
       "url": "https://github.com/simonw/datasette/releases/tag/0.33"
     },
     {
+      "author": "simonw",
       "published_at": "2019-11-14T23:42:14Z",
       "published_day": "2019-11-14",
       "release": "Datasette 0.32",
       "url": "https://github.com/simonw/datasette/releases/tag/0.32"
     },
     {
+      "author": "simonw",
       "published_at": "2019-11-13T17:38:59Z",
       "published_day": "2019-11-13",
       "release": "0.31.2",
       "url": "https://github.com/simonw/datasette/releases/tag/0.31.2"
     },
     {
+      "author": "simonw",
       "published_at": "2019-11-13T02:40:53Z",
       "published_day": "2019-11-13",
       "release": "0.31.1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.31.1"
     },
     {
+      "author": "simonw",
       "published_at": "2019-11-13T02:16:15Z",
       "published_day": "2019-11-13",
       "release": "Datasette 0.31",
       "url": "https://github.com/simonw/datasette/releases/tag/0.31"
     },
     {
+      "author": "simonw",
       "published_at": "2019-11-02T23:33:13Z",
       "published_day": "2019-11-02",
       "release": "0.30.2",
       "url": "https://github.com/simonw/datasette/releases/tag/0.30.2"
     },
     {
+      "author": "simonw",
       "published_at": "2019-11-02T00:06:02Z",
       "published_day": "2019-11-02",
       "release": "0.30.1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.30.1"
     },
     {
+      "author": "simonw",
       "published_at": "2019-10-30T18:51:30Z",
       "published_day": "2019-10-30",
       "release": "0.30",
       "url": "https://github.com/simonw/datasette/releases/tag/0.30"
     },
     {
+      "author": "simonw",
       "published_at": "2019-10-18T05:24:54Z",
       "published_day": "2019-10-18",
       "release": "0.29.3",
       "url": "https://github.com/simonw/datasette/releases/tag/0.29.3"
     },
     {
+      "author": "simonw",
       "published_at": "2019-09-03T00:33:35Z",
       "published_day": "2019-09-03",
       "release": "0.29.2",
       "url": "https://github.com/simonw/datasette/releases/tag/0.29.2"
     },
     {
+      "author": "simonw",
       "published_at": "2019-07-14T01:43:44Z",
       "published_day": "2019-07-14",
       "release": "0.29.1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.29.1"
     },
     {
+      "author": "simonw",
       "published_at": "2019-07-08T03:43:13Z",
       "published_day": "2019-07-08",
       "release": "Datasette 0.29",
       "url": "https://github.com/simonw/datasette/releases/tag/0.29"
     },
     {
+      "author": "simonw",
       "published_at": "2019-05-19T21:42:28Z",
       "published_day": "2019-05-19",
       "release": "Datasette 0.28",
       "url": "https://github.com/simonw/datasette/releases/tag/0.28"
     },
     {
+      "author": "simonw",
       "published_at": "2019-02-06T05:10:20Z",
       "published_day": "2019-02-06",
       "release": "Datasette 0.27",
       "url": "https://github.com/simonw/datasette/releases/tag/0.27"
     },
     {
+      "author": "simonw",
       "published_at": "2019-01-28T01:50:45Z",
       "published_day": "2019-01-28",
       "release": "Datasette 0.26.1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.26.1"
     },
     {
+      "author": "simonw",
       "published_at": "2019-01-10T21:41:00Z",
       "published_day": "2019-01-10",
       "release": "Datasette 0.26",
       "url": "https://github.com/simonw/datasette/releases/tag/0.26"
     },
     {
+      "author": "simonw",
       "published_at": "2018-12-16T21:45:39Z",
       "published_day": "2018-12-16",
       "release": "Datasette 0.25.2",
       "url": "https://github.com/simonw/datasette/releases/tag/0.25.2"
     },
     {
+      "author": "simonw",
       "published_at": "2018-12-16T21:44:27Z",
       "published_day": "2018-12-16",
       "release": "Datasette 0.25.1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.25.1"
     },
     {
+      "author": "simonw",
       "published_at": "2018-09-19T18:27:21Z",
       "published_day": "2018-09-19",
       "release": "Datasette 0.25",
       "url": "https://github.com/simonw/datasette/releases/tag/0.25"
     },
     {
+      "author": "simonw",
       "published_at": "2018-07-24T16:51:29Z",
       "published_day": "2018-07-24",
       "release": "Datasette 0.24",
       "url": "https://github.com/simonw/datasette/releases/tag/0.24"
     },
     {
+      "author": "simonw",
       "published_at": "2018-07-08T05:41:38Z",
       "published_day": "2018-07-08",
       "release": "Datasette 0.23.2",
       "url": "https://github.com/simonw/datasette/releases/tag/0.23.2"
     },
     {
+      "author": "simonw",
       "published_at": "2018-06-21T16:02:44Z",
       "published_day": "2018-06-21",
       "release": "Datasette 0.23.1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.23.1"
     },
     {
+      "author": "simonw",
       "published_at": "2018-06-18T15:28:37Z",
       "published_day": "2018-06-18",
       "release": "Datasette 0.23: CSV, SpatiaLite and more",
       "url": "https://github.com/simonw/datasette/releases/tag/0.23"
     },
     {
+      "author": "simonw",
       "published_at": "2018-05-23T14:04:17Z",
       "published_day": "2018-05-23",
       "release": "Datasette 0.22.1",
       "url": "https://github.com/simonw/datasette/releases/tag/0.22.1"
     },
     {
+      "author": "simonw",
       "published_at": "2018-05-20T23:44:19Z",
       "published_day": "2018-05-20",
       "release": "Datasette 0.22: Datasette Facets",
       "url": "https://github.com/simonw/datasette/releases/tag/0.22"
     },
     {
+      "author": "simonw",
       "published_at": "2018-05-05T23:21:33Z",
       "published_day": "2018-05-05",
       "release": "Datasette 0.21: New _shape=, new _size=, search within columns",
       "url": "https://github.com/simonw/datasette/releases/tag/0.21"
     },
     {
+      "author": "simonw",
       "published_at": "2018-04-20T14:41:14Z",
       "published_day": "2018-04-20",
       "release": "Datasette 0.20: static assets and templates for plugins",
       "url": "https://github.com/simonw/datasette/releases/tag/0.20"
     },
     {
+      "author": "simonw",
       "published_at": "2018-04-17T02:21:51Z",
       "published_day": "2018-04-17",
       "release": "Datasette 0.19: plugins preview",
       "url": "https://github.com/simonw/datasette/releases/tag/0.19"
     },
     {
+      "author": "simonw",
       "published_at": "2018-04-14T15:45:11Z",
       "published_day": "2018-04-14",
       "release": "Datasette 0.18: units",
       "url": "https://github.com/simonw/datasette/releases/tag/0.18"
     },
     {
+      "author": "simonw",
       "published_at": "2018-04-13T21:10:53Z",
       "published_day": "2018-04-13",
       "release": "Datasette 0.16: sort on mobile, better error handling",
       "url": "https://github.com/simonw/datasette/releases/tag/0.16"
     },
     {
+      "author": "simonw",
       "published_at": "2018-04-09T15:55:29Z",
       "published_day": "2018-04-09",
       "release": "Datasette 0.15: sort by column",
       "url": "https://github.com/simonw/datasette/releases/tag/0.15"
     },
     {
+      "author": "simonw",
       "published_at": "2017-12-10T01:41:14Z",
       "published_day": "2017-12-10",
       "release": "Datasette 0.14: customization edition",
       "url": "https://github.com/simonw/datasette/releases/tag/0.14"
     },
     {
+      "author": "simonw",
       "published_at": "2017-11-25T03:44:46Z",
       "published_day": "2017-11-25",
       "release": "Datasette 0.13: foreign key, search and filters",
       "url": "https://github.com/simonw/datasette/releases/tag/0.13"
     },
     {
+      "author": "simonw",
       "published_at": "2017-11-16T16:01:35Z",
       "published_day": "2017-11-16",
       "release": "Datasette 0.12",

--- a/repos/simonw/pge-outages/README.md
+++ b/repos/simonw/pge-outages/README.md
@@ -1,0 +1,25 @@
+# pge-outages
+
+This repository tracks outages reported on the [PG&E outages map](https://pgealerts.alerts.pge.com/outage-tools/outage-map/) over time, using [Git scraping](https://simonwillison.net/2020/Oct/9/git-scraping/).
+
+This repository started tracking outages on 4th February 2024. The implementation of the scraper can be found in [.github/workflows/fetch.yml](https://github.com/simonw/pge-outages/blob/main/.github/workflows/fetch.yml) - it uses a combination of `curl` and `jq`.
+
+The most recently tracked outages are in [outages.json](https://github.com/simonw/pge-outages/blob/main/outages.json). The [commit history](https://github.com/simonw/pge-outages/commits/main/outages.json) of that file shows outages recorded over time.
+
+A previous version of this repository ran from from 2019 to 2022. That data can now be found in [simonw/pge-outages-pre-2024](https://github.com/simonw/pge-outages-pre-2024/)
+
+## Incomplete data warning
+
+This repository only archives outages that are reported for a single location.
+
+The outage map also includes polygon data, which is much more interesting... but has not proven practical to archive here, for [reasons explained in this issue comment](https://github.com/simonw/pge-outages/issues/4#issuecomment-1928758853). Short version: I'd have to constantly archive 100MB of data per snapshot because the polygons are so large!
+
+## Browsing the latest data in Datasette Lite
+
+Use this URL to open the latest `outages.json` in [Datasette Lite](https://github.com/simonw/datasette-lite):
+
+https://lite.datasette.io/?json=https://github.com/simonw/pge-outages/blob/main/outages.json#/data/outages?_facet=CITY&_facet=OUTAGE_CAUSE&_facet=CREW_CURRENT_STATUS&_facet=OUTAGE_EXTENT
+
+It will look something like this:
+
+![Screenshot of Datasette Lite, faceting 674 outages by city, cause, crew current status and outage extent](https://github.com/simonw/pge-outages/assets/9599/ac0999f2-349a-4db7-a005-2ba42133dde0)

--- a/repos/simonw/pge-outages/releases.json
+++ b/repos/simonw/pge-outages/releases.json
@@ -1,0 +1,8 @@
+{
+  "description": "Tracking PG&E power outages",
+  "owner": "simonw",
+  "releases": [],
+  "repo": "pge-outages",
+  "total_releases": 0,
+  "url": "https://github.com/simonw/pge-outages"
+}

--- a/repos/simonw/scrape-fema-shelters/README.md
+++ b/repos/simonw/scrape-fema-shelters/README.md
@@ -1,0 +1,13 @@
+# scrape-fema-shelters
+
+A [Git scraper](https://simonwillison.net/2020/Oct/9/git-scraping/) tracking the official feed of FEMA emergency shelters.
+
+To convert this to SQLite using [git-history](https://github.com/simonw/git-history):
+
+```bash
+git-history file fema.db fema-shelters.json --convert '
+geojson = json.loads(content)
+for feature in geojson["features"]:
+    yield feature["properties"]
+' --ignore objectid --id SHELTER_ID
+```

--- a/repos/simonw/scrape-fema-shelters/releases.json
+++ b/repos/simonw/scrape-fema-shelters/releases.json
@@ -1,0 +1,8 @@
+{
+  "description": null,
+  "owner": "simonw",
+  "releases": [],
+  "repo": "scrape-fema-shelters",
+  "total_releases": 0,
+  "url": "https://github.com/simonw/scrape-fema-shelters"
+}

--- a/repos/simonw/scrape-florida-outages/releases.json
+++ b/repos/simonw/scrape-florida-outages/releases.json
@@ -1,0 +1,8 @@
+{
+  "description": null,
+  "owner": "simonw",
+  "releases": [],
+  "repo": "scrape-florida-outages",
+  "total_releases": 0,
+  "url": "https://github.com/simonw/scrape-florida-outages"
+}

--- a/repos/simonw/simonwillisonblog-backup/README.md
+++ b/repos/simonw/simonwillisonblog-backup/README.md
@@ -1,0 +1,7 @@
+# simonwillisonblog-backup
+
+Uses [db-to-sqlite](https://github.com/simonw/db-to-sqlite) and [sqlite-diffable](https://github.com/simonw/sqlite-diffable) to pull a backup of the Heroku PostgreSQL database running https://simonwillison.net/ and store it as newline-delimited JSON in this GitHub repository.
+
+Runs as a GitHub Actions workflow, see [.github/workflows/backup.yml](https://github.com/simonw/simonwillisonblog-backup/blob/main/.github/workflows/backup.yml).
+
+Deploys a Datasette instance to https://datasette.simonwillison.net/

--- a/repos/simonw/simonwillisonblog-backup/releases.json
+++ b/repos/simonw/simonwillisonblog-backup/releases.json
@@ -1,0 +1,8 @@
+{
+  "description": "Backups of the database for simonwillison.net",
+  "owner": "simonw",
+  "releases": [],
+  "repo": "simonwillisonblog-backup",
+  "total_releases": 0,
+  "url": "https://github.com/simonw/simonwillisonblog-backup"
+}

--- a/repos/simonw/usgs-scraper/README.md
+++ b/repos/simonw/usgs-scraper/README.md
@@ -1,0 +1,1 @@
+# usgs-scraper

--- a/repos/simonw/usgs-scraper/releases.json
+++ b/repos/simonw/usgs-scraper/releases.json
@@ -1,0 +1,8 @@
+{
+  "description": null,
+  "owner": "simonw",
+  "releases": [],
+  "repo": "usgs-scraper",
+  "total_releases": 0,
+  "url": "https://github.com/simonw/usgs-scraper"
+}


### PR DESCRIPTION
I want to be able to clone just this repo and have information about ALL my other repos, mainly to work around GitHub API rate limits!

- build_readme.py now fetches each repo's README inline in the GraphQL
  search query (no extra fetches) and writes repos/<owner>/<repo>/README.md
  plus releases.json for every repo, including zero-release ones.
- Unified the search query; --all (or --seed) does a full scan of every
  repo, otherwise the scheduled run only looks at repos pushed in the
  last 3 hours.
- workflow_dispatch gains an "all" option to run against everything.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LWcxQ6Y6h58RDJxCQ8iE6B