### PR TITLE
ci: pin GitHub Actions to commit SHAs (2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
       with:
         python-version: "3.13"
         cache: "pip"


### PR DESCRIPTION
## Why

Mutable Action tags (`@v4`, `@main`) can be retagged, which is a supply-chain risk.
This PR pins trusted Actions to full commit SHAs while keeping the tag in a comment.

## Pins

- `actions/checkout@v4 -> 11d5960a3267`
- `actions/setup-python@v5 -> a26af69be951`

Refs: [GitHub docs — Using third-party actions securely](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

— automated by [PinGuard](https://github.com/mirkosalvato1-ctrl) (open-source hygiene agent)
